### PR TITLE
Lua input devices + seat cleanup

### DIFF
--- a/runtime/base_config.lua
+++ b/runtime/base_config.lua
@@ -37,8 +37,8 @@ mez.input.add_keymap(mod .. "|shift", "Q", {
 })
 
 mez.hook.add("ViewSetFocusPost", {
-	callback = function (view_id, focus)
-    if focus then
+	callback = function(view_id, _, focus_count)
+    if focus_count > 0 then
       mez.view.set_border(view_id, { color = "#FFDD33", width = border_width })
     else
       mez.view.set_border(view_id, { color = "#52493E", width = border_width })
@@ -53,8 +53,8 @@ mez.hook.add("ViewMapPre", {
 })
 
 mez.hook.add("ViewPointerMotion", {
-	callback = function (view_id, _, _)
-		mez.view.set_focused(0, view_id)
+	callback = function (view_id, _, _, seat_id)
+    mez.seat.set_focused_view(seat_id, view_id)
 	end
 })
 

--- a/runtime/master.lua
+++ b/runtime/master.lua
@@ -9,7 +9,7 @@ local utils = {}
 ---@return number | nil tag_index
 ---@return number | nil view_index
 utils.find_view = function(view_id)
-	if view_id == 0 then view_id = mez.view.get_focused_id(0) end
+	if view_id == 0 then view_id = mez.seat.get_focused_view(0) end
 
 	for i, curr_tag in ipairs(M.state.tags) do
 		local t = M.state.tags[i]
@@ -136,7 +136,7 @@ M.add_view = function(view_id)
 		table.insert(tag.stack, #tag.stack + 1, view_id)
 	end
 
-	if M.config.focus_on_spawn then mez.view.set_focused(0, view_id) end
+	if M.config.focus_on_spawn then mez.seat.set_focused_view(0, view_id) end
 
 	M.tile_tag(M.state.tag_id)
 end
@@ -144,37 +144,37 @@ end
 ---Move the focus in a tag to the next view
 ---Order is master -> stack -> floating -> master
 M.focus_next = function()
-	local view_id = mez.view.get_focused_id(0)
+	local view_id = mez.seat.get_focused_view(0)
 	local type, tag_idx, view_idx = utils.find_view(view_id)
 	local tag = M.state.tags[tag_idx]
 
 	if type == "floating" then
 		if view_idx == #tag.floating then
 			if tag.master ~= nil then
-				mez.view.set_focused(0, tag.master)
+				mez.seat.set_focused_view(0, tag.master)
 			else
-				mez.view.set_focused(0, tag.floating[1])
+				mez.seat.set_focused_view(0, tag.floating[1])
 			end
 		else
-			mez.view.set_focused(0, tag.floating[view_idx + 1])
+			mez.seat.set_focused_view(0, tag.floating[view_idx + 1])
 		end
 	elseif type == "master" then
 		if #tag.stack ~= 0 then
-			mez.view.set_focused(0, tag.stack[1])
+			mez.seat.set_focused_view(0, tag.stack[1])
 		elseif #tag.floating ~= 0 then
-			mez.view.set_focused(0, tag.floating[1])
+			mez.seat.set_focused_view(0, tag.floating[1])
 		else
-			mez.view.set_focused(0, tag.master)
+			mez.seat.set_focused_view(0, tag.master)
 		end
 	elseif type == "stacking" then
 		if view_idx == #tag.stack then
 			if #tag.floating ~= 0 then
-				mez.view.set_focused(0, tag.floating[1])
+				mez.seat.set_focused_view(0, tag.floating[1])
 			else
-				mez.view.set_focused(0, tag.master)
+				mez.seat.set_focused_view(0, tag.master)
 			end
 		else
-			mez.view.set_focused(0, tag.stack[view_idx + 1])
+			mez.seat.set_focused_view(0, tag.stack[view_idx + 1])
 		end
 	end
 end
@@ -182,35 +182,35 @@ end
 ---Move the focus in a tag to the previous view
 ---Order is master -> floating -> stack -> master
 M.focus_prev = function()
-	local view_id = mez.view.get_focused_id(0)
+	local view_id = mez.seat.get_focused_view(0)
 	local type, tag_idx, view_idx = utils.find_view(view_id)
 	local tag = M.state.tags[tag_idx]
 
 	if type == "floating" then
 		if view_idx == 1 then
 			if #tag.stack ~= 0 then
-				mez.view.set_focused(0, tag.stack[#tag.stack])
+				mez.seat.set_focused_view(0, tag.stack[#tag.stack])
 			elseif tag.master ~= nil then
-				mez.view.set_focused(0, tag.master)
+				mez.seat.set_focused_view(0, tag.master)
 			else
-				mez.view.set_focused(0, tag.floating[#tag.floating])
+				mez.seat.set_focused_view(0, tag.floating[#tag.floating])
 			end
 		else
-			mez.view.set_focused(0, tag.floating[view_idx - 1])
+			mez.seat.set_focused_view(0, tag.floating[view_idx - 1])
 		end
 	elseif type == "master" then
 		if #tag.floating ~= 0 then
-			mez.view.set_focused(0, tag.floating[#tag.floating])
+			mez.seat.set_focused_view(0, tag.floating[#tag.floating])
 		elseif #tag.stack ~= 0 then
-			mez.view.set_focused(0, tag.stack[#tag.stack])
+			mez.seat.set_focused_view(0, tag.stack[#tag.stack])
 		else
-			mez.view.set_focused(0, tag.master)
+			mez.seat.set_focused_view(0, tag.master)
 		end
 	elseif type == "stacking" then
 		if view_idx == 1 then
-			mez.view.set_focused(0, tag.master)
+			mez.seat.set_focused_view(0, tag.master)
 		else
-			mez.view.set_focused(0, tag.stack[view_idx - 1])
+			mez.seat.set_focused_view(0, tag.stack[view_idx - 1])
 		end
 	end
 end
@@ -218,7 +218,7 @@ end
 ---Remove a view_id from the layout
 ---@param view_id integer
 M.remove_view = function(view_id)
-  if view_id == 0 then view_id = mez.view.get_focused_id(0) end
+  if view_id == 0 then view_id = mez.seat.get_focused_view(0) end
 
 	local type, tag_idx, view_idx = utils.find_view(view_id)
 
@@ -231,7 +231,7 @@ M.remove_view = function(view_id)
 		tag.master = table.remove(tag.stack, 1)
 
 		if M.config.refocus_on_kill then
-			mez.view.set_focused(0, tag.master)
+			mez.seat.set_focused_view(0, tag.master)
 		end
 	elseif type == "stacking" then
 		local is_last = #tag.stack == view_idx
@@ -240,9 +240,9 @@ M.remove_view = function(view_id)
 
 		if M.config.refocus_on_kill then
 			if #tag.stack == 0 then
-				mez.view.set_focused(0, tag.master)
+				mez.seat.set_focused_view(0, tag.master)
 			else
-				mez.view.set_focused(0, tag.stack[is_last and view_idx - 1 or view_idx])
+				mez.seat.set_focused_view(0, tag.stack[is_last and view_idx - 1 or view_idx])
 			end
 		end
 	end
@@ -264,22 +264,22 @@ M.tag_enable = function (tag_idx)
 
         if utils.find_view(tag.last_focused) == nil then
           if tag.master then
-            mez.view.set_focused(0, tag.master)
+            mez.seat.set_focused_view(0, tag.master)
           elseif #tag.floating ~= 0 then
-            mez.view.set_focused(0, tag.floating[1])
+            mez.seat.set_focused_view(0, tag.floating[1])
           end
         else
-          mez.view.set_focused(0, tag.last_focused)
+          mez.seat.set_focused_view(0, tag.last_focused)
         end
       else
         if tag.master then
-          mez.view.set_focused(0, tag.master)
+          mez.seat.set_focused_view(0, tag.master)
         elseif #tag.floating ~= 0 then
-          mez.view.set_focused(0, tag.floating[1])
+          mez.seat.set_focused_view(0, tag.floating[1])
         end
       end
 		else
-			tag.last_focused = mez.view.get_focused_id(0)
+			tag.last_focused = mez.seat.get_focused_view(0)
 		end
 
 		for _, v in ipairs(tag.floating) do
@@ -304,7 +304,7 @@ end
 ---Move a stack window to the master, and vice versa
 ---@param view_id integer
 M.zoom = function (view_id)
-	if view_id == 0 then view_id = mez.view.get_focused_id(0) end
+	if view_id == 0 then view_id = mez.seat.get_focused_view(0) end
 	local type, tag_idx, view_idx = utils.find_view(view_id)
 
 	if type == "floating" or type == "master" or M.state.tag_id ~= tag_idx then return end
@@ -352,7 +352,7 @@ M.make_float = function (view_id)
 	end
 
 	mez.view.raise_to_top(tag.floating[#tag.floating])
-	mez.view.set_focused(0, tag.floating[#tag.floating])
+	mez.seat.set_focused_view(0, tag.floating[#tag.floating])
 	M.tile_tag(tag_idx)
 end
 
@@ -387,7 +387,7 @@ end
 ---@param view_id integer
 ---@param tag_id number
 M.send_view = function (view_id, tag_id)
-  if view_id == 0 then view_id = mez.view.get_focused_id(0) end
+  if view_id == 0 then view_id = mez.seat.get_focused_view(0) end
   if tag_id == M.state.tag_id then return end
 
 	local type, _, _ = utils.find_view(view_id)

--- a/src/Cursor.zig
+++ b/src/Cursor.zig
@@ -187,6 +187,7 @@ pub fn processCursorMotion(
                 surface.scene_node_data.view.id,
                 @as(c_int, @intFromFloat(self.wlr_cursor.x)),
                 @as(c_int, @intFromFloat(self.wlr_cursor.y)),
+                self.seat.id(),
             }, "After the cursor moves, but before anyone is told about it.");
         }
 

--- a/src/Keyboard.zig
+++ b/src/Keyboard.zig
@@ -33,6 +33,8 @@ destroy: wl.Listener(*wlr.InputDevice) = .init(handleDestroy),
 pub fn init(device: *wlr.InputDevice) *Keyboard {
     const self = gpa.create(Keyboard) catch Utils.oomPanic();
 
+    // TODO: there is no world where pluggin in a keyboard should crash the
+    // compositor >:(
     errdefer {
         std.log.err("Unable to initialize new keyboard, exiting", .{});
         std.process.exit(6);

--- a/src/KeyboardGroup.zig
+++ b/src/KeyboardGroup.zig
@@ -50,6 +50,12 @@ pub fn addKeyboard(self: *KeyboardGroup, keyboard: *Keyboard) void {
     keyboard.group = self;
 }
 
+pub fn removeKeyboard(self: *KeyboardGroup, keyboard: *Keyboard) void {
+    _ = keyboard.wlr_keyboard.setKeymap(null);
+    self.wlr_group.removeKeyboard(keyboard.wlr_keyboard);
+    keyboard.group = null;
+}
+
 pub fn deinit(self: *KeyboardGroup) void {
     self.wlr_group.destroy();
     gpa.destroy(self);

--- a/src/Seat.zig
+++ b/src/Seat.zig
@@ -191,6 +191,16 @@ pub fn addInputDevice(self: *Seat, device: *wlr.InputDevice) void {
         },
         .pointer => {
             self.cursor.wlr_cursor.attachInputDevice(device);
+            device.data = &self.cursor;
+        },
+        else => |t| std.log.err("unsupported input method: {}", .{ t }),
+    }
+
+    self.wlr_seat.setCapabilities(.{
+        .keyboard = true,
+        .pointer = true,
+    });
+}
         },
         else => |t| std.log.err("unsupported input method: {}", .{ t }),
     }

--- a/src/Seat.zig
+++ b/src/Seat.zig
@@ -120,6 +120,16 @@ pub fn deinit(self: *Seat) void {
     self.wlr_seat.destroy();
 }
 
+pub fn id(self: *Seat) u32 {
+    var iter_seat = server.seats.iterator(.forward);
+    var i: u32 = 0;
+    while (iter_seat.next()) |v| : (i += 1) {
+        if (v == self) return i;
+    }
+
+    std.debug.panic("Trying to get id of seat not in the server's list of seats!", .{});
+}
+
 pub fn focusSurface(self: *Seat, to_focus: ?FocusData) void {
     if (to_focus == null) {
         self.focused_surface = to_focus;

--- a/src/Seat.zig
+++ b/src/Seat.zig
@@ -11,6 +11,7 @@ const KeyboardGroup = @import("KeyboardGroup.zig");
 const Keyboard = @import("Keyboard.zig");
 const Cursor = @import("Cursor.zig");
 const Utils = @import("Utils.zig");
+const input_device = @import("input_device.zig");
 const Popup = @import("Popup.zig");
 const View = @import("View.zig");
 const LayerSurface = @import("LayerSurface.zig");
@@ -175,7 +176,7 @@ pub fn focusOutput(self: *Seat, output: *Output) void {
 pub fn addInputDevice(self: *Seat, device: *wlr.InputDevice) void {
     switch (device.type) {
         .keyboard => {
-            const keyboard = Keyboard.init(device);
+            const keyboard = (input_device.get(device) orelse return).keyboard;
             self.keyboard_group.addKeyboard(keyboard);
         },
         .pointer => {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -278,14 +278,14 @@ pub fn deinit(self: *Server) noreturn {
 // --------- Backend event handlers ---------
 fn handleNewInput(listener: *wl.Listener(*wlr.InputDevice), device: *wlr.InputDevice) void {
     const self: *Server = @fieldParentPtr("new_input", listener);
-    std.log.info("creating a new input device {s}", .{ @tagName(device.type)});
 
     // create the device
     input_device.create(device);
 
     self.events.exec("DeviceAddPre", .{ device }, "Called before a new device is added to the compositor.");
-    const dev = input_device.get(device) orelse unreachable;
+    const dev = input_device.get(device) orelse return;
 
+    // has the user already given the device to a seat?
     const seated = switch (dev) {
         .keyboard => |keyboard| if (keyboard.group != null) true else false,
         .pointer => |pointer| if (pointer.base.data != null) true else false,
@@ -293,13 +293,6 @@ fn handleNewInput(listener: *wl.Listener(*wlr.InputDevice), device: *wlr.InputDe
     };
 
     if (!seated) self.getDefaultSeat().addInputDevice(device);
-    // dev.keyboard.group.?.removeKeyboard(dev.keyboard);
-
-    // We should really only set true capabilities
-    self.getDefaultSeat().wlr_seat.setCapabilities(.{
-        .pointer = true,
-        .keyboard = true,
-    });
 
     self.events.exec("DeviceAddPost", .{ device }, "Called after a new device is added to the compositor.");
 }

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -383,10 +383,7 @@ fn handleNewVirtualPointer(
     event: *wlr.VirtualPointerManagerV1.event.NewPointer,
 ) void {
     const self: *Server = @fieldParentPtr("new_virtual_pointer", listener);
-    const device = &event.new_pointer.pointer.base;
-
-    self.getDefaultSeat().cursor.wlr_cursor.attachInputDevice(device);
-    self.getDefaultSeat().cursor.wlr_cursor.mapInputToOutput(device, event.suggested_output);
+    handleNewInput(&self.new_input, &event.new_pointer.pointer.base);
 }
 
 fn handleNewVirtualKeyboard(
@@ -394,10 +391,7 @@ fn handleNewVirtualKeyboard(
     event: *wlr.VirtualKeyboardV1,
 ) void {
     const self: *Server = @fieldParentPtr("new_virtual_keyboard", listener);
-    const device = &event.keyboard.base;
-
-    const keyboard = Keyboard.init(device);
-    _ = self.getDefaultSeat().keyboard_group.wlr_group.addKeyboard(keyboard.wlr_keyboard);
+    handleNewInput(&self.new_input, &event.keyboard.base);
 }
 
 fn handleNewIdleInhibitor(

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -15,6 +15,7 @@ const IdleInhibitor = @import("IdleInhibitor.zig");
 const IdleNotifier = @import("IdleNotifer.zig");
 const Hook = @import("lua/Hook.zig");
 const Async = @import("lua/Async.zig");
+const input_device = @import("input_device.zig");
 const Popup = @import("Popup.zig");
 const RemoteLua = @import("RemoteLua.zig");
 const RemoteLuaManager = @import("RemoteLuaManager.zig");
@@ -277,13 +278,30 @@ pub fn deinit(self: *Server) noreturn {
 // --------- Backend event handlers ---------
 fn handleNewInput(listener: *wl.Listener(*wlr.InputDevice), device: *wlr.InputDevice) void {
     const self: *Server = @fieldParentPtr("new_input", listener);
-    self.getDefaultSeat().addInputDevice(device);
+    std.log.info("creating a new input device {s}", .{ @tagName(device.type)});
+
+    // create the device
+    input_device.create(device);
+
+    self.events.exec("DeviceAddPre", .{ device }, "Called before a new device is added to the compositor.");
+    const dev = input_device.get(device) orelse unreachable;
+
+    const seated = switch (dev) {
+        .keyboard => |keyboard| if (keyboard.group != null) true else false,
+        .pointer => |pointer| if (pointer.base.data != null) true else false,
+        else => false,
+    };
+
+    if (!seated) self.getDefaultSeat().addInputDevice(device);
+    // dev.keyboard.group.?.removeKeyboard(dev.keyboard);
 
     // We should really only set true capabilities
     self.getDefaultSeat().wlr_seat.setCapabilities(.{
         .pointer = true,
         .keyboard = true,
     });
+
+    self.events.exec("DeviceAddPost", .{ device }, "Called after a new device is added to the compositor.");
 }
 
 fn handleNewOutput(listener: *wl.Listener(*wlr.Output), wlr_output: *wlr.Output) void {

--- a/src/View.zig
+++ b/src/View.zig
@@ -14,6 +14,7 @@ const gpa = std.heap.c_allocator;
 const server = &@import("main.zig").server;
 
 id: u64,
+focus_count: u32,
 
 output: ?*Output,
 
@@ -64,6 +65,7 @@ pub fn init(xdg_toplevel: *wlr.XdgToplevel) *View {
 
     self.* = .{
         .id = @intFromPtr(xdg_toplevel),
+        .focus_count = 0,
         .output = null,
         .geometry = .{ .width = 0, .height = 0, .x = 0, .y = 0 },
         .previous_geometry = .{ .width = 0, .height = 0, .x = 0, .y = 0 },
@@ -220,9 +222,13 @@ pub fn resizeBorders(self: *View) void {
 }
 
 pub fn setActivated(self: *View, activated: bool) void {
-    server.events.exec("ViewSetFocusPre", .{ self.id, activated }, "Before a view's focus is set");
-    _ = self.xdg_toplevel.setActivated(activated);
-    server.events.exec("ViewSetFocusPost", .{ self.id, activated }, "After a view's focus is set");
+    if (activated) self.focus_count += 1 else self.focus_count -= 1;
+
+    server.events.exec("ViewSetFocusPre", .{ self.id, activated, self.focus_count }, "Before a view's focus is set");
+
+    _ = self.xdg_toplevel.setActivated(if (self.focus_count == 0) false else true);
+
+    server.events.exec("ViewSetFocusPost", .{ self.id, activated, self.focus_count }, "After a view's focus is set");
 }
 
 pub fn fromSurface(surface: *wlr.Surface) ?*View {

--- a/src/input_device.zig
+++ b/src/input_device.zig
@@ -1,0 +1,41 @@
+const input_device = @This();
+
+const std = @import("std");
+const wlr = @import("wlroots");
+
+const Keyboard = @import("Keyboard.zig");
+
+pub const InputDevice = union(wlr.InputDevice.Type) {
+    keyboard: *Keyboard,
+    pointer: *wlr.Pointer,
+    touch: void,
+    tablet: void,
+    tablet_pad: void,
+    @"switch": void,
+};
+
+pub fn create(device: *wlr.InputDevice) void {
+    switch (device.type) {
+        .keyboard => {
+            const keyboard = Keyboard.init(device);
+            device.data = keyboard;
+        },
+        .pointer => {
+            // the data attached here is used to figure out which seat owns
+            // the pointer
+            device.data = null;
+        },
+        else => |t| std.log.err("unsupported input method: {}", .{ t }),
+    }
+}
+
+pub fn get(device: *wlr.InputDevice) ?InputDevice {
+    return switch (device.type) {
+        .keyboard => .{ .keyboard = @alignCast(@ptrCast(device.data)) },
+        .pointer => .{ .pointer = device.toPointer(), },
+        else => |t| blk: {
+            std.log.err("unsupported input method: {}", .{ t });
+            break :blk null;
+        },
+    };
+}

--- a/src/lua/Device.zig
+++ b/src/lua/Device.zig
@@ -3,25 +3,22 @@ const std = @import("std");
 const zlua = @import("zlua");
 const wlr = @import("wlroots");
 
-const Utils = @import("../Utils.zig");
-const input_device = @import("../input_device.zig");
-const LuaUtils = @import("LuaUtils.zig");
-
-const gpa = std.heap.c_allocator;
-
-const server = &@import("../main.zig").server;
-const Lua = &@import("../main.zig").lua;
-
 fn device_error(L: *zlua.Lua) noreturn {
     L.raiseErrorStr("Unable to get device.", .{});
 }
 
+/// ---Get the type of a device
+/// ---@param device userdata
+/// ---@return string type
 pub fn get_type(L: *zlua.Lua) i32 {
     const device = L.toUserdata(wlr.InputDevice, 1) catch device_error(L);
     _ = L.pushString(std.mem.span(@tagName(device.type).ptr));
     return 1;
 }
 
+/// ---Get the name of a device
+/// ---@param device userdata
+/// ---@return string name
 pub fn get_name(L: *zlua.Lua) i32 {
     const device = L.toUserdata(wlr.InputDevice, 1) catch device_error(L);
     _ = if (device.name) |n| L.pushString(std.mem.span(n)) else L.pushNil();

--- a/src/lua/Device.zig
+++ b/src/lua/Device.zig
@@ -1,0 +1,29 @@
+//! mez.device
+const std = @import("std");
+const zlua = @import("zlua");
+const wlr = @import("wlroots");
+
+const Utils = @import("../Utils.zig");
+const input_device = @import("../input_device.zig");
+const LuaUtils = @import("LuaUtils.zig");
+
+const gpa = std.heap.c_allocator;
+
+const server = &@import("../main.zig").server;
+const Lua = &@import("../main.zig").lua;
+
+fn device_error(L: *zlua.Lua) noreturn {
+    L.raiseErrorStr("Unable to get device.", .{});
+}
+
+pub fn get_type(L: *zlua.Lua) i32 {
+    const device = L.toUserdata(wlr.InputDevice, 1) catch device_error(L);
+    _ = L.pushString(std.mem.span(@tagName(device.type).ptr));
+    return 1;
+}
+
+pub fn get_name(L: *zlua.Lua) i32 {
+    const device = L.toUserdata(wlr.InputDevice, 1) catch device_error(L);
+    _ = if (device.name) |n| L.pushString(std.mem.span(n)) else L.pushNil();
+    return 1;
+}

--- a/src/lua/Lua.zig
+++ b/src/lua/Lua.zig
@@ -133,6 +133,7 @@ pub fn openMezLibs(self: *zlua.Lua) void {
     inline for (.{
         .{ "api", @import("Api.zig") },
         .{ "async", @import("Async.zig") },
+        .{ "device", @import("Device.zig") },
         .{ "fs", @import("Fs.zig") },
         .{ "hook", @import("Hook.zig") },
         .{ "input", @import("Input.zig") },

--- a/src/lua/Output.zig
+++ b/src/lua/Output.zig
@@ -46,27 +46,6 @@ pub fn get_all_ids(L: *zlua.Lua) i32 {
     return 1;
 }
 
-/// ---Get the id for the focused output
-/// ---@param integer? seat seat id, nil for the default seat
-/// ---@return integer? result nil if the seat provided doesn't exist
-pub fn get_focused_id(L: *zlua.Lua) i32 {
-    const seat = if (!L.isNil(1)) blk: {
-        const seat_id = LuaUtils.coerceInteger(u32, L.checkInteger(1)) catch Seat.seat_id_err(L);
-        break :blk LuaUtils.seatFromId(seat_id) orelse {
-            L.pushNil();
-            return 1;
-        };
-    } else server.getDefaultSeat();
-
-    if (seat.focused_output) |output| {
-        L.pushInteger(@intCast(output.id));
-        return 1;
-    }
-
-    L.pushNil();
-    return 1;
-}
-
 /// ---Remove focus from current output, and set to given id
 /// ---@param seat_id integer Id of the seat to be focused, 0 for default seat
 /// ---@param output_id integer? Id of the output to be focused

--- a/src/lua/Output.zig
+++ b/src/lua/Output.zig
@@ -46,26 +46,6 @@ pub fn get_all_ids(L: *zlua.Lua) i32 {
     return 1;
 }
 
-/// ---Remove focus from current output, and set to given id
-/// ---@param seat_id integer Id of the seat to be focused, 0 for default seat
-/// ---@param output_id integer? Id of the output to be focused
-pub fn set_focused(L: *zlua.Lua) i32 {
-    const seat = if (!L.isNil(1)) blk: {
-        const seat_id = LuaUtils.coerceInteger(u32, L.checkInteger(1)) catch Seat.seat_id_err(L);
-        break :blk LuaUtils.seatFromId(seat_id) orelse {
-            L.pushNil();
-            return 1;
-        };
-    } else server.getDefaultSeat();
-    const output_id = LuaUtils.coerceInteger(u64, L.checkInteger(2)) catch output_id_err(L);
-    if (server.root.outputById(output_id)) |output| {
-        seat.focusOutput(output);
-    }
-
-    L.pushNil();
-    return 1;
-}
-
 /// Returns all the ids of views within an output
 /// ---@param output_id integer 0 maps to focused output
 /// ---@return integer[]?

--- a/src/lua/Seat.zig
+++ b/src/lua/Seat.zig
@@ -69,6 +69,20 @@ pub fn remove(L: *zlua.Lua) i32 {
 // TODO: finish this
 pub fn add_intput_device(L: *zlua.Lua) i32 {
     _ = L;
+
+/// ---Remove focus from current view, and set to given id
+/// ---@param seat_id integer Id of the seat to be focused, 0 for default seat
+/// ---@param view_id integer? Id of the view to be focused, or nil to remove focus
+pub fn set_focused_view(L: *zlua.Lua) i32 {
+    const seat_id = LuaUtils.coerceInteger(u32, L.checkInteger(1)) catch seat_id_err(L);
+    const seat = LuaUtils.seatFromId(seat_id) orelse seat_id_err(L);
+    const view_id: ?c_longlong = L.optInteger(2);
+
+    if (view_id == null) {
+        seat.focusSurface(null);
+    } else if (server.root.viewById(@intCast(view_id.?))) |view| {
+        seat.focusSurface(.{ .view = view });
+    }
     return 0;
 }
 
@@ -89,6 +103,20 @@ pub fn get_focused_view(L: *zlua.Lua) i32 {
 
     L.pushNil();
     return 1;
+}
+
+/// ---Remove focus from current output, and set to given id
+/// ---@param seat_id integer Id of the seat to be focused
+/// ---@param output_id integer? Id of the output to be focused
+pub fn set_focused_output(L: *zlua.Lua) i32 {
+    const seat_id = LuaUtils.coerceInteger(u32, L.checkInteger(1)) catch seat_id_err(L);
+    const seat = LuaUtils.seatFromId(seat_id) orelse seat_id_err(L);
+
+    const output_id = LuaUtils.coerceInteger(u64, L.checkInteger(2)) catch L.raiseErrorStr("Invalid output id", .{});
+    if (server.root.outputById(output_id)) |output| {
+        seat.focusOutput(output);
+    }
+    return 0;
 }
 
 /// ---Get the focused output of a seat

--- a/src/lua/Seat.zig
+++ b/src/lua/Seat.zig
@@ -3,6 +3,7 @@ const Seat = @This();
 
 const std = @import("std");
 const zlua = @import("zlua");
+const wlr = @import("wlroots");
 
 const LuaUtils = @import("LuaUtils.zig");
 const Utils = @import("../Utils.zig");
@@ -41,6 +42,9 @@ pub fn create(L: *zlua.Lua) i32 {
         );
     }
 
+    // the new seat starts on the same output as the default seat
+    seat.focused_output = server.getDefaultSeat().focused_output;
+
     server.seats.append(seat);
 
     L.pushInteger(@intCast(server.seats.length() - 1));
@@ -66,9 +70,46 @@ pub fn remove(L: *zlua.Lua) i32 {
     return 1;
 }
 
-// TODO: finish this
-pub fn add_intput_device(L: *zlua.Lua) i32 {
-    _ = L;
+/// ---Get a seats name
+/// ---@param seat_id integer
+/// ---@return string seat name
+pub fn get_name(L: *zlua.Lua) i32 {
+    const seat_id = LuaUtils.coerceInteger(u32, L.checkInteger(1)) catch seat_id_err(L);
+    const seat = LuaUtils.seatFromId(seat_id);
+
+    if (seat) |s| {
+        _ = L.pushString(std.mem.span(s.wlr_seat.name));
+        return 1;
+    }
+
+    L.pushNil();
+    return 1;
+}
+
+/// ---Set a seats name
+/// ---@param seat_id integer
+/// ---@param name string
+pub fn set_name(L: *zlua.Lua) i32 {
+    const seat_id = LuaUtils.coerceInteger(u32, L.checkInteger(1)) catch seat_id_err(L);
+    const seat = LuaUtils.seatFromId(seat_id);
+    const name = L.toString(2) catch L.raiseErrorStr("Invalid seat name", .{});
+
+    if (seat) |s| s.wlr_seat.setName(name);
+    return 0;
+}
+
+/// ---add an input device to a seat
+/// ---@param seat integer seat id
+/// ---@param device userdata device
+pub fn add_device(L: *zlua.Lua) i32 {
+    const seat_id = LuaUtils.coerceInteger(u32, L.checkInteger(1)) catch seat_id_err(L);
+    const seat = LuaUtils.seatFromId(seat_id);
+
+    const device = L.toUserdata(wlr.InputDevice, 2) catch L.raiseErrorStr("Unable to get device.", .{});
+
+    if (seat) |s| s.addInputDevice(device);
+    return 0;
+}
 
 /// ---Remove focus from current view, and set to given id
 /// ---@param seat_id integer Id of the seat to be focused, 0 for default seat

--- a/src/lua/Seat.zig
+++ b/src/lua/Seat.zig
@@ -66,7 +66,11 @@ pub fn remove(L: *zlua.Lua) i32 {
     return 1;
 }
 
-// TODO(squibid): add_input_device
+// TODO: finish this
+pub fn add_intput_device(L: *zlua.Lua) i32 {
+    _ = L;
+    return 0;
+}
 
 /// ---Set the repeat information for a seat
 /// ---@param seat integer seat id

--- a/src/lua/Seat.zig
+++ b/src/lua/Seat.zig
@@ -72,6 +72,41 @@ pub fn add_intput_device(L: *zlua.Lua) i32 {
     return 0;
 }
 
+/// ---Get the focused view of a seat
+/// ---@param seat_id seat seat id
+/// ---@return view_id? result nil if the seat provided doesn't exist or nothing is focused
+pub fn get_focused_view(L: *zlua.Lua) i32 {
+    const seat_id = LuaUtils.coerceInteger(u32, L.checkInteger(1)) catch seat_id_err(L);
+    const seat = LuaUtils.seatFromId(seat_id);
+
+    if (seat) |s| if (s.focused_surface) |surface| switch (surface) {
+        .view => |v| {
+            L.pushInteger(@intCast(v.id));
+            return 1;
+        },
+        .layer_surface => {},
+    };
+
+    L.pushNil();
+    return 1;
+}
+
+/// ---Get the focused output of a seat
+/// ---@param seat_id seat seat id
+/// ---@return output_id? result nil if the seat provided doesn't exist or nothing is focused
+pub fn get_focused_output(L: *zlua.Lua) i32 {
+    const seat_id = LuaUtils.coerceInteger(u32, L.checkInteger(1)) catch seat_id_err(L);
+    const seat = LuaUtils.seatFromId(seat_id);
+
+    if (seat) |s| if (s.focused_output) |output| {
+        L.pushInteger(@intCast(output.id));
+        return 1;
+    };
+
+    L.pushNil();
+    return 1;
+}
+
 /// ---Set the repeat information for a seat
 /// ---@param seat integer seat id
 /// ---@param rate integer

--- a/src/lua/View.zig
+++ b/src/lua/View.zig
@@ -166,29 +166,6 @@ pub fn get_previous_geometry(L: *zlua.Lua) i32 {
     return 1;
 }
 
-/// ---Remove focus from current view, and set to given id
-/// ---@param seat_id integer Id of the seat to be focused, 0 for default seat
-/// ---@param view_id integer? Id of the view to be focused, or nil to remove focus
-pub fn set_focused(L: *zlua.Lua) i32 {
-    const seat = if (!L.isNil(1)) blk: {
-        const seat_id = LuaUtils.coerceInteger(u32, L.checkInteger(1)) catch Seat.seat_id_err(L);
-        break :blk LuaUtils.seatFromId(seat_id) orelse {
-            L.pushNil();
-            return 1;
-        };
-    } else server.getDefaultSeat();
-    const view_id: ?c_longlong = L.optInteger(2);
-
-    if (view_id == null) {
-        seat.focusSurface(null);
-    } else if (server.root.viewById(@intCast(view_id.?))) |view| {
-        seat.focusSurface(.{ .view = view });
-    }
-
-    L.pushNil();
-    return 1;
-}
-
 /// ---Toggle the view to enter fullscreen. Will enter the fullscreen layer
 /// ---and remove any preexisting fullscreened view for it's output.
 /// ---@param view_id integer 0 maps to focused view

--- a/src/lua/View.zig
+++ b/src/lua/View.zig
@@ -52,29 +52,6 @@ pub fn get_all_ids(L: *zlua.Lua) i32 {
     return 1;
 }
 
-/// ---Get the id for the focused view
-/// ---@param integer? seat seat id, nil for the default seat
-/// ---@return integer? result nil if the seat provided doesn't exist
-pub fn get_focused_id(L: *zlua.Lua) i32 {
-    const seat = if (!L.isNil(1)) blk: {
-        const seat_id = LuaUtils.coerceInteger(u32, L.checkInteger(1)) catch Seat.seat_id_err(L);
-        break :blk LuaUtils.seatFromId(seat_id) orelse {
-            L.pushNil();
-            return 1;
-        };
-    } else server.getDefaultSeat();
-
-    if (seat.focused_surface) |fs| {
-        if (fs == .view) {
-            L.pushInteger(@intCast(fs.view.id));
-            return 1;
-        }
-    }
-
-    L.pushNil();
-    return 1;
-}
-
 /// ---Close the view with view_id
 /// ---@param view_id integer 0 maps to focused view
 pub fn close(L: *zlua.Lua) i32 {


### PR DESCRIPTION
This pr introduces the ability to add input devices to specific seats (closing #42)!
- [x] add devices to a seat
- [ ] remove devices from a seat
- [x] getters for device info
  - [x] name
  - [x] type
- [x] events!
  - [x] DeviceAddPre
  - [x] DeviceAddPost 

I've also tried to draw a finer line between the ownership of focus related functions:
- [x] `mez.view.set_focused` -> `mez.seat.set_focused_view`
- [x] `mez.view.get_focused` -> `mez.seat.get_focused_view`
- [x] `mez.output.set_focused` -> `mez.seat.set_focused_output`
- [x] `mez.output.get_focused` -> `mez.seat.get_focused_output`

And I've also added some more functions for interacting with seats:
- [x] set name
- [x] get name